### PR TITLE
added method to dump trie to writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: go
 
 go:
-  - 1.0
-  - 1.1
-  - 1.2
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - master
 
 install:
   - go get github.com/fvbock/uds-go/set


### PR DESCRIPTION
Avoided duplicating too much code and also improved memory usage during the dump process. Closing #4 